### PR TITLE
Fixes missing FuBar menu entries - 

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -702,6 +702,8 @@ NampowerOptions.defaultMinimapPosition = 180
 NampowerOptions.independentProfile = true
 NampowerOptions.hideWithoutStandby = false
 
+NampowerOptions:RegisterDB("NampowerSettingsDB")
+
 NampowerOptions.OnMenuRequest = Nampower.cmdtable
 local args = AceLibrary("FuBarPlugin-2.0"):GetAceOptionsDataTable(NampowerOptions)
 for k, v in pairs(args) do


### PR DESCRIPTION
Added NampowerOptions:RegisterDB("NampowerSettingsDB") as @wormuz suggested in #2 

The standard FuBar menu entries (Show icon, Show text, Show colored text) are missing without this, so there's no way to hide the rather space filling  "Nampower Settings" on the FuBar.

Before and after - 
<img width="1107" height="513" alt="image" src="https://github.com/user-attachments/assets/24657c04-3a8e-429c-b6a8-8fda8e3bd4fd" />

I've just been adding this in myself and neglecting to tell anyone 🤦

After with text hidden👌 - 
<img width="182" height="35" alt="image" src="https://github.com/user-attachments/assets/b88cbdb6-af93-46ed-b6bb-0731bda9d99d" />

I'm sure there's hardly any other FuBar users left to benefit 🤷‍♀️
